### PR TITLE
bugfix: use clientId, not client_id, with createAuth0Client

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -8,7 +8,7 @@ import config from "../auth_config";
 async function createClient() {
     let auth0Client = await createAuth0Client({
         domain: config.domain,
-        client_id: config.clientId
+        clientId: config.clientId
       });
 
       return auth0Client


### PR DESCRIPTION
In the example code you are using `client_id` in the options parameter. This does not work (Auth0 complains about client_id not beeing passed when logging in). 

The correct Client ID options parameter for `createAuth0Client` should be `clientId`.  

Refering to the auth0-spa-js docs: https://auth0.com/docs/libraries/auth0-single-page-app-sdk#create-the-client